### PR TITLE
Adds a panel_id variable to config to allow specifying a panel

### DIFF
--- a/config/filament-authentication-log.php
+++ b/config/filament-authentication-log.php
@@ -22,4 +22,5 @@ return [
         'direction' => 'desc',
     ],
 
+    'panel_id' => 'admin'
 ];

--- a/config/filament-authentication-log.php
+++ b/config/filament-authentication-log.php
@@ -21,6 +21,4 @@ return [
         'column' => 'login_at',
         'direction' => 'desc',
     ],
-
-    'panel_id' => 'admin'
 ];

--- a/src/RelationManagers/AuthenticationLogsRelationManager.php
+++ b/src/RelationManagers/AuthenticationLogsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentAuthenticationLog\RelationManagers;
 
+use Filament\Facades\Filament;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
@@ -34,7 +35,7 @@ class AuthenticationLogsRelationManager extends RelationManager
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.'.config('filament-authentication-log.panel_id').'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="'.route('filament.'.Filament::getCurrentPanel()->getId().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')

--- a/src/RelationManagers/AuthenticationLogsRelationManager.php
+++ b/src/RelationManagers/AuthenticationLogsRelationManager.php
@@ -34,7 +34,7 @@ class AuthenticationLogsRelationManager extends RelationManager
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.admin.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="'.route('filament.'.config('filament-authentication-log.panel_id').'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -74,7 +74,7 @@ class AuthenticationLogResource extends Resource
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.admin.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="'.route('filament.'.config('filament-authentication-log.panel_id').'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -2,6 +2,7 @@
 
 namespace Tapp\FilamentAuthenticationLog\Resources;
 
+use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Form;
@@ -74,7 +75,7 @@ class AuthenticationLogResource extends Resource
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.'.config('filament-authentication-log.panel_id').'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="'.route('filament.'.Filament::getCurrentPanel()->getId().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')


### PR DESCRIPTION
Fixes #1 

This adds a new config variable called `panel_id` (defaults to admin) which will allow a developer to specify which panel the logs will be shown on.

Currently the panel_id is hardcoded to the default of `admin`, this means if you are not using the admin panel then you are unable to use this plugin as it looks for the admin panel by id. 

In my use case, I use Filament as the entire application and there is no specific admin area, so it makes sense for me to use a different ID other than admin.

I appreciate your time reviewing this PR, the plugin does exactly what I need with this simple config fix.