### PR TITLE
Use custom resource from config in list page

### DIFF
--- a/src/Resources/AuthenticationLogResource/Pages/ListAuthenticationLogs.php
+++ b/src/Resources/AuthenticationLogResource/Pages/ListAuthenticationLogs.php
@@ -7,5 +7,8 @@ use Tapp\FilamentAuthenticationLog\Resources\AuthenticationLogResource;
 
 class ListAuthenticationLogs extends ListRecords
 {
-    protected static string $resource = AuthenticationLogResource::class;
+    public static function getResource(): string
+    {
+        return config('filament-authentication-log.resources.AutenticationLogResource', AuthenticationLogResource::class);
+    }
 }


### PR DESCRIPTION
Needed to overwrite the list page to ensure the authenticatable is loaded fixing:
> Attempted to lazy load [authenticatable] on model [Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog] but lazy loading is disabled.