### PR TITLE
Option to pass custom panelName, showing name of Actual user name instead of Class Name

### DIFF
--- a/src/FilamentAuthenticationLogPlugin.php
+++ b/src/FilamentAuthenticationLogPlugin.php
@@ -3,10 +3,13 @@
 namespace Tapp\FilamentAuthenticationLog;
 
 use Filament\Contracts\Plugin;
+use Filament\Facades\Filament;
 use Filament\Panel;
 
 class FilamentAuthenticationLogPlugin implements Plugin
 {
+    protected ?string $panelName = null;
+
     public static function make(): static
     {
         return app(static::class);
@@ -28,5 +31,22 @@ class FilamentAuthenticationLogPlugin implements Plugin
     public function boot(Panel $panel): void
     {
         //
+    }
+
+    public static function get(): Plugin
+    {
+        return filament(app(static::class)->getId());
+    }
+
+    public function getPanelName(): ?string
+    {
+        return $this->panelName ?? Filament::getCurrentPanel()->getId();
+    }
+
+    public function panelName(string $name): static
+    {
+        $this->panelName = $name;
+
+        return $this;
     }
 }

--- a/src/RelationManagers/AuthenticationLogsRelationManager.php
+++ b/src/RelationManagers/AuthenticationLogsRelationManager.php
@@ -31,11 +31,11 @@ class AuthenticationLogsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))
                     ->formatStateUsing(function (?string $state, Model $record) {
-                        if (! $record->authenticatable_id) {
+                        if (!$record->authenticatable_id) {
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.'.Filament::getCurrentPanel()->getId().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="' . route('filament.' . Filament::getCurrentPanel()->getId() . '.resources.' . Str::plural((Str::lower(class_basename($record->authenticatable::class)))) . '.edit', ['record' => $record->authenticatable_id]) . '" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">' . $record->authenticatable->name . '</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -73,7 +73,6 @@ class AuthenticationLogResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->with('authenticatable'))
             ->columns([
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -73,6 +73,7 @@ class AuthenticationLogResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('authenticatable'))
             ->columns([
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -2,20 +2,21 @@
 
 namespace Tapp\FilamentAuthenticationLog\Resources;
 
-use Filament\Facades\Filament;
 use Filament\Forms;
-use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Form;
-use Filament\Resources\Resource;
 use Filament\Tables;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\Filter;
+use Filament\Forms\Form;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Filament\Facades\Filament;
+use Filament\Resources\Resource;
+use Illuminate\Support\HtmlString;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Database\Eloquent\Model;
+use Filament\Forms\Components\DatePicker;
+use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog;
+use Tapp\FilamentAuthenticationLog\FilamentAuthenticationLogPlugin;
 use Tapp\FilamentAuthenticationLog\Resources\AuthenticationLogResource\Pages;
 
 class AuthenticationLogResource extends Resource
@@ -76,11 +77,11 @@ class AuthenticationLogResource extends Resource
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))
                     ->formatStateUsing(function (?string $state, Model $record) {
-                        if (! $record->authenticatable_id) {
+                        if (!$record->authenticatable_id) {
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.'.Filament::getCurrentPanel()->getId().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="' . route('filament.' . FilamentAuthenticationLogPlugin::get()->getPanelName() . '.resources.' . Str::plural((Str::lower(class_basename($record->authenticatable::class)))) . '.edit', ['record' => $record->authenticatable_id]) . '" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">' . $record->authenticatable->name . '</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')


### PR DESCRIPTION
Usage of this:

`FilamentAuthenticationLogPlugin::make()->panelName('admin')`

_However, this is optional_

Why I did this?
- I have 2 Panels, Developer and Admin.
- Where `FilamentAuthenticationLogPlugin` will be used only in developer, but user Resource will be available in admin panel only.


`$record->authenticatable->name`

This will show the name of the Actual username instead of Class Name, which will be good when seeing all the logs at a time. 


Below Code to use in Model if you don't have name column:
```
public function getNameAttribute(): string
{
    return trim($this->first_name . ' ' . $this->last_name);
}
```
