### PR TITLE
Option to pass custom panelName, showing name of Actual user name instead of Class Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ php artisan vendor:publish --tag="filament-authentication-log-config"
 
 ## Using the Resource
 
-Add this plugin to a panel on `plugins()` method. 
-E.g. in `app/Providers/Filament/AdminPanelProvider.php`:
+Add this plugin to a panel in the `plugins()` method. 
+E.g., in `app/Providers/Filament/AdminPanelProvider.php`:
 
 ```php
 use Tapp\FilamentAuthenticationLog\FilamentAuthenticationLogPlugin;
@@ -62,13 +62,15 @@ public function panel(Panel $panel): Panel
     return $panel
         // ...
         ->plugins([
-            FilamentAuthenticationLogPlugin::make(),
-            //...
+            FilamentAuthenticationLogPlugin::make()
+                // ->panelName('admin') // Optional: specify the panel name if needed
         ]);
 }
 ```
 
 That's it! Now you can see the Authentication Log resource on left sidebar.
+
+This customization `->panelName('admin')` allows for better organization if you have multiple panels, such as Developer and Admin panels, where the `FilamentAuthenticationLogPlugin` is used in one panel but the user resource is available only in another panel.
 
 ### Resource appearance
 
@@ -98,3 +100,26 @@ public static function getRelations(): array
 ### Relation manager appearance
 
 ![Filament Authentication Log Relation Manager](https://raw.githubusercontent.com/TappNetwork/filament-authentication-log/main/docs/relation_manager.png)
+
+### Displaying Authenticatable Names
+
+To display the actual name of the authenticatable user instead of the class name, you can configure the plugin to show a specific field. By default, it will use the `name` field if available. If your model does not have a `name` column, you can add a custom attribute:
+
+In your model:
+
+```php
+public function getNameAttribute(): string
+{
+    return trim($this->first_name . ' ' . $this->last_name);
+}
+```
+
+### Configuration
+
+To specify a custom field to display for the authenticatable user, update the `config/filament-authentication-log.php` configuration file:
+
+```php
+'authenticatable' => [
+    'field-to-display' => 'name', // Change 'name' to your custom field if needed
+],
+```

--- a/config/filament-authentication-log.php
+++ b/config/filament-authentication-log.php
@@ -10,6 +10,10 @@ return [
         \App\Models\User::class,
     ],
 
+    'authenticatable' => [
+        'field-to-display' => 'name',
+    ],
+
     'navigation' => [
         'authentication-log' => [
             'register' => true,

--- a/config/filament-authentication-log.php
+++ b/config/filament-authentication-log.php
@@ -11,7 +11,7 @@ return [
     ],
 
     'authenticatable' => [
-        'field-to-display' => 'name',
+        'field-to-display' => null,
     ],
 
     'navigation' => [

--- a/src/FilamentAuthenticationLogPlugin.php
+++ b/src/FilamentAuthenticationLogPlugin.php
@@ -3,10 +3,13 @@
 namespace Tapp\FilamentAuthenticationLog;
 
 use Filament\Contracts\Plugin;
+use Filament\Facades\Filament;
 use Filament\Panel;
 
 class FilamentAuthenticationLogPlugin implements Plugin
 {
+    protected ?string $panelName = null;
+
     public static function make(): static
     {
         return app(static::class);
@@ -28,5 +31,22 @@ class FilamentAuthenticationLogPlugin implements Plugin
     public function boot(Panel $panel): void
     {
         //
+    }
+
+    public static function get(): Plugin
+    {
+        return filament(app(static::class)->getId());
+    }
+
+    public function getPanelName(): ?string
+    {
+        return $this->panelName ?? Filament::getCurrentPanel()->getId();
+    }
+
+    public function panelName(string $name): static
+    {
+        $this->panelName = $name;
+
+        return $this;
     }
 }

--- a/src/RelationManagers/AuthenticationLogsRelationManager.php
+++ b/src/RelationManagers/AuthenticationLogsRelationManager.php
@@ -31,11 +31,11 @@ class AuthenticationLogsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))
                     ->formatStateUsing(function (?string $state, Model $record) {
-                        if (! $record->authenticatable_id) {
+                        if (!$record->authenticatable_id) {
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.'.Filament::getCurrentPanel()->getId().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="' . route('filament.' . Filament::getCurrentPanel()->getId() . '.resources.' . Str::plural((Str::lower(class_basename($record->authenticatable::class)))) . '.edit', ['record' => $record->authenticatable_id]) . '" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">' . $record->authenticatable->name . '</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -2,20 +2,20 @@
 
 namespace Tapp\FilamentAuthenticationLog\Resources;
 
-use Filament\Facades\Filament;
 use Filament\Forms;
-use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Form;
-use Filament\Resources\Resource;
 use Filament\Tables;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\Filter;
+use Filament\Forms\Form;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Filament\Resources\Resource;
+use Illuminate\Support\HtmlString;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Database\Eloquent\Model;
+use Filament\Forms\Components\DatePicker;
+use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog;
+use Tapp\FilamentAuthenticationLog\FilamentAuthenticationLogPlugin;
 use Tapp\FilamentAuthenticationLog\Resources\AuthenticationLogResource\Pages;
 
 class AuthenticationLogResource extends Resource
@@ -72,15 +72,16 @@ class AuthenticationLogResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('authenticatable'))
             ->columns([
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))
                     ->formatStateUsing(function (?string $state, Model $record) {
-                        if (! $record->authenticatable_id) {
+                        if (!$record->authenticatable_id) {
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="'.route('filament.'.Filament::getCurrentPanel()->getId().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 text-sm font-medium filament-tables-link-action">'.class_basename($record->authenticatable::class).'</a>');
+                        return new HtmlString('<a href="' . route('filament.' . FilamentAuthenticationLogPlugin::get()->getPanelName() . '.resources.' . Str::plural((Str::lower(class_basename($record->authenticatable::class)))) . '.edit', ['record' => $record->authenticatable_id]) . '" class="inline-flex items-center justify-center text-sm font-medium hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 filament-tables-link-action">' . $record->authenticatable->name . '</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -77,11 +77,15 @@ class AuthenticationLogResource extends Resource
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))
                     ->formatStateUsing(function (?string $state, Model $record) {
+                        $authenticatableFieldToDisplay = config('filament-authentication-log.authenticatable.field-to-display');
+
+                        $authenticatableDisplay = $authenticatableFieldToDisplay !== null ? $record->authenticatable->{$authenticatableFieldToDisplay} : class_basename($record->authenticatable::class);
+
                         if (!$record->authenticatable_id) {
                             return new HtmlString('&mdash;');
                         }
 
-                        return new HtmlString('<a href="' . route('filament.' . FilamentAuthenticationLogPlugin::get()->getPanelName() . '.resources.' . Str::plural((Str::lower(class_basename($record->authenticatable::class)))) . '.edit', ['record' => $record->authenticatable_id]) . '" class="inline-flex items-center justify-center text-sm font-medium hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 filament-tables-link-action">' . $record->authenticatable->name . '</a>');
+                        return new HtmlString('<a href="' . route('filament.' . FilamentAuthenticationLogPlugin::get()->getPanelName() . '.resources.' . Str::plural((Str::lower(class_basename($record->authenticatable::class)))) . '.edit', ['record' => $record->authenticatable_id]) . '" class="inline-flex items-center justify-center text-sm font-medium hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 filament-tables-link-action">' . $authenticatableDisplay . '</a>');
                     })
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ip_address')


### PR DESCRIPTION
Usage of this:

`FilamentAuthenticationLogPlugin::make()->panelName('admin')`

_However, this is optional_

Why I did this?
- I have 2 Panels, Developer and Admin.
- Where `FilamentAuthenticationLogPlugin` will be used only in developer, but user Resource will be available in admin panel only.


`$record->authenticatable->name`

This will show the name of the Actual username instead of Class Name, which will be good when seeing all the logs at a time. 


Below Code to use in Model if you don't have name column:
```
public function getNameAttribute(): string
{
    return trim($this->first_name . ' ' . $this->last_name);
}
```

Had N+1 Query Issue when Getting Username, that too fixed by adding Below Query to Resource Table

`->modifyQueryUsing(fn (Builder $query) => $query->with('authenticatable'))`