### PR TITLE
fix: fixed AuthLogResource Table default sort order

### DIFF
--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -72,7 +72,7 @@ class AuthenticationLogResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->with('authenticatable'))
+            ->modifyQueryUsing(fn (Builder $query) => $query->orderBy(config('filament-authentication-log.sort.column'), config('filament-authentication-log.sort.direction')))
             ->columns([
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -72,7 +72,14 @@ class AuthenticationLogResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->orderBy(config('filament-authentication-log.sort.column'), config('filament-authentication-log.sort.direction')))
+            ->modifyQueryUsing(function (Builder $query) {
+                $query->with('authenticatable')
+                    ->orderBy(
+                        column: config('filament-authentication-log.sort.column', 'login_at'),
+                        direction: config('filament-authentication-log.sort.direction', 'desc')
+                    );
+                }
+            )    
             ->columns([
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -72,14 +72,11 @@ class AuthenticationLogResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(function (Builder $query) {
-                $query->with('authenticatable')
-                    ->orderBy(
-                        column: config('filament-authentication-log.sort.column', 'login_at'),
-                        direction: config('filament-authentication-log.sort.direction', 'desc')
-                    );
-                }
-            )    
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('authenticatable'))
+            ->defaultSort(
+                config('filament-authentication-log.sort.column'),
+                config('filament-authentication-log.sort.direction'),
+            )
             ->columns([
                 Tables\Columns\TextColumn::make('authenticatable')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.authenticatable'))

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -91,7 +91,7 @@ class AuthenticationLogResource extends Resource
 
                         return new HtmlString('<a href="'.route('filament.'.FilamentAuthenticationLogPlugin::get()->getPanelName().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit', ['record' => $record->authenticatable_id]).'" class="inline-flex items-center justify-center text-sm font-medium hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 filament-tables-link-action">'.$authenticatableDisplay.'</a>');
                     })
-                    ->sortable(),
+                    ->sortable(['authenticatable_id']),
                 Tables\Columns\TextColumn::make('ip_address')
                     ->label(trans('filament-authentication-log::filament-authentication-log.column.ip_address'))
                     ->searchable()


### PR DESCRIPTION
This pull request includes a change to the `src/Resources/AuthenticationLogResource.php` file to enhance the query modification for the authentication log table. The most important change is the addition of sorting functionality based on configuration settings.

Previously the sort column and direction keys in the config file were used only on the `src/RelationsManagers/AuthenticationLogsRelationManager`.

Enhancements to query modification:

* [`src/Resources/AuthenticationLogResource.php`](diffhunk://#diff-066ed960e2600743b548444989e7801e7cffdf1e4a20ec0534b670a47668f04dL75-R82): Modified the `modifyQueryUsing` method to include sorting by a configurable column and direction. This change allows the authentication log entries to be ordered by a specified column and direction, enhancing the flexibility of the logging system.