### PR TITLE
Add Laravel Authentication log v6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^4.0|^5.0",
-        "rappasoft/laravel-authentication-log": "^5.0",
+        "rappasoft/laravel-authentication-log": "^6.0|^5.0",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
# Details

Add Laravel Authentication log v6 support:

https://github.com/rappasoft/laravel-authentication-log/releases/tag/v6.0.0
https://github.com/rappasoft/laravel-authentication-log/blob/main/UPGRADE.md

Fix https://github.com/TappNetwork/filament-authentication-log/issues/43
