### PR TITLE
Add Portuguese (pt_BR) translations for Filament Authentication Log

### DIFF
--- a/resources/lang/pt_BR/filament-authentication-log.php
+++ b/resources/lang/pt_BR/filament-authentication-log.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'navigation.group' => 'Logins',
+
+    'navigation.authentication-log.label' => 'Log de Autenticação',
+    'navigation.authentication-log.plural-label' => 'Logs de Autenticação',
+
+    'table.heading' => 'Logs de Autenticação',
+    'table.empty' => 'Nenhum log de autenticação encontrado',
+
+    'column.authenticatable' => 'Autenticável',
+    'column.ip_address' => 'Endereço IP',
+    'column.user_agent' => 'Agente do Usuário',
+    'column.login_at' => 'Login em',
+    'column.login_successful' => 'Login bem-sucedido',
+    'column.logout_at' => 'Logout em',
+    'column.cleared_by_user' => 'Limpo pelo Usuário',
+];


### PR DESCRIPTION
This PR adds **pt_BR (Brazilian Portuguese)** language support to the FilamentPHP package.

A new `pt_BR` directory was created containing the full set of translations for the package, following the same structure and key patterns used by the existing languages. No application logic or behavior was modified — this change is limited strictly to localization files.

### Changes

- Added `resources/lang/pt_BR` directory  
- Included Brazilian Portuguese translations for the package  
- Ensured consistency with existing translation keys and structure  

### Impact

- Improves usability for Brazilian Portuguese-speaking users  
- No breaking changes  
- No impact on existing functionality  