### PR TITLE
Drop PHP 8.2 support, add PHP 8.5

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3]
         laravel: ['11.*', '12.*']
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "source": "https://github.com/TappNetwork/filament-authentication-log"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "filament/filament": "^4.0|^5.0",
         "rappasoft/laravel-authentication-log": "^6.0|^5.0",
         "spatie/laravel-package-tools": "^1.9"


### PR DESCRIPTION
## Summary

- Drops PHP 8.2 from the test matrix and raises the minimum requirement in `composer.json` to `^8.3`
- Adds PHP 8.5 to the test matrix in `run-tests.yml`
- Updates `phpstan.yml` to run static analysis on PHP 8.5

## Changes

| File | Change |
|------|--------|
| `composer.json` | `"php": "^8.2"` → `"php": "^8.3"` |
| `.github/workflows/run-tests.yml` | Matrix `[8.4, 8.3, 8.2]` → `[8.5, 8.4, 8.3]` |
| `.github/workflows/phpstan.yml` | `php-version: '8.3'` → `php-version: '8.5'` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)