### PR TITLE
Add configurable authenticatable resource page

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,21 @@ To specify a custom field to display for the authenticatable user, update the `c
 ```php
 'authenticatable' => [
     'field-to-display' => 'name', // Change 'name' to your custom field if needed
+    'resource-page' => 'edit', // Change 'edit' to another resource page, such as 'view'
 ],
 ```
+
+### Authenticatable Resource Page
+
+By default, the authenticatable link points to the `edit` page of the detected Filament resource. To link to another resource page, such as `view`, update the `resource-page` configuration value:
+
+```php
+'authenticatable' => [
+    'resource-page' => 'view',
+],
+```
+
+Make sure the target resource defines the configured page name.
 
 ### Custom User Resource
 

--- a/config/filament-authentication-log.php
+++ b/config/filament-authentication-log.php
@@ -15,6 +15,7 @@ return [
 
     'authenticatable' => [
         'field-to-display' => null,
+        'resource-page' => 'edit',
     ],
 
     'navigation' => [

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -98,7 +98,9 @@ class AuthenticationLogResource extends Resource
 
                         $authenticableEditRoute = '#';
 
-                        $routeName = 'filament.'.FilamentAuthenticationLogPlugin::get()->getPanelName().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.edit';
+                        $authenticatableResourcePage = config('filament-authentication-log.authenticatable.resource-page', 'edit');
+
+                        $routeName = 'filament.'.FilamentAuthenticationLogPlugin::get()->getPanelName().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.'.$authenticatableResourcePage;
 
                         if (Route::has($routeName)) {
                             $authenticableEditRoute = route($routeName, ['record' => $record->authenticatable_id]);
@@ -180,11 +182,13 @@ class AuthenticationLogResource extends Resource
 
         $userResource = config('filament-authentication-log.user-resource');
 
-        // Check if the resource exists and has an edit page
+        $authenticatableResourcePage = config('filament-authentication-log.authenticatable.resource-page', 'edit');
+
+        // Check if the resource exists and has the configured page
         if (method_exists($userResource, 'getUrl') &&
             method_exists($userResource, 'hasPage') &&
-            $userResource::hasPage('edit')) {
-            $authenticableEditRoute = $userResource::getUrl('edit', ['record' => $record->authenticatable_id]);
+            $userResource::hasPage($authenticatableResourcePage)) {
+            $authenticableEditRoute = $userResource::getUrl($authenticatableResourcePage, ['record' => $record->authenticatable_id]);
         }
 
         return $authenticableEditRoute;

--- a/src/Resources/AuthenticationLogResource.php
+++ b/src/Resources/AuthenticationLogResource.php
@@ -96,19 +96,19 @@ class AuthenticationLogResource extends Resource
                             return new HtmlString('&mdash;');
                         }
 
-                        $authenticableEditRoute = '#';
+                        $authenticatableRoute = '#';
 
                         $authenticatableResourcePage = config('filament-authentication-log.authenticatable.resource-page', 'edit');
 
                         $routeName = 'filament.'.FilamentAuthenticationLogPlugin::get()->getPanelName().'.resources.'.Str::plural((Str::lower(class_basename($record->authenticatable::class)))).'.'.$authenticatableResourcePage;
 
                         if (Route::has($routeName)) {
-                            $authenticableEditRoute = route($routeName, ['record' => $record->authenticatable_id]);
+                            $authenticatableRoute = route($routeName, ['record' => $record->authenticatable_id]);
                         } elseif (config('filament-authentication-log.user-resource')) {
-                            $authenticableEditRoute = self::getCustomUserRoute($record);
+                            $authenticatableRoute = self::getCustomUserResourceRoute($record);
                         }
 
-                        return new HtmlString('<a href="'.$authenticableEditRoute.'" class="inline-flex items-center justify-center text-sm font-medium hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 filament-tables-link-action">'.$authenticatableDisplay.'</a>');
+                        return new HtmlString('<a href="'.$authenticatableRoute.'" class="inline-flex items-center justify-center text-sm font-medium hover:underline focus:outline-none focus:underline filament-tables-link text-primary-600 hover:text-primary-500 filament-tables-link-action">'.$authenticatableDisplay.'</a>');
                     })
                     ->sortable(['authenticatable_id']),
                 TextColumn::make('ip_address')
@@ -176,9 +176,9 @@ class AuthenticationLogResource extends Resource
             ]);
     }
 
-    protected static function getCustomUserRoute($record)
+    protected static function getCustomUserResourceRoute($record)
     {
-        $authenticableEditRoute = '#';
+        $authenticatableRoute = '#';
 
         $userResource = config('filament-authentication-log.user-resource');
 
@@ -188,10 +188,10 @@ class AuthenticationLogResource extends Resource
         if (method_exists($userResource, 'getUrl') &&
             method_exists($userResource, 'hasPage') &&
             $userResource::hasPage($authenticatableResourcePage)) {
-            $authenticableEditRoute = $userResource::getUrl($authenticatableResourcePage, ['record' => $record->authenticatable_id]);
+            $authenticatableRoute = $userResource::getUrl($authenticatableResourcePage, ['record' => $record->authenticatable_id]);
         }
 
-        return $authenticableEditRoute;
+        return $authenticatableRoute;
     }
 
     public static function getRelations(): array


### PR DESCRIPTION
## Summary

This PR adds a new configuration option that allows users to customize which Filament resource page the authenticatable link should point to.

Previously, the authenticatable column always attempted to link to the `edit` page of the detected resource. With this change, users can now configure the target page, such as `view`, while keeping `edit` as the default behavior.

## Changes

- Added `authenticatable.resource-page` config option
- Defaults the authenticatable link target to `edit`
- Uses the configured page when building detected resource routes
- Uses the same configured page for the custom `user-resource` fallback
- Updated README with usage example

## Example

```php
// config/filament-authentication-log.php

'authenticatable' => [
    // ...
    'resource-page' => 'view',
],
```