### PR TITLE
Fix Composer test scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,8 @@
     },
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage-html coverage"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
## Summary
- update Composer test scripts to run Pest instead of PHPUnit directly
- update coverage script to use Pest's coverage flag

## Verification
- composer test
- composer analyse
- vendor/bin/pint --test